### PR TITLE
Use strict json for settings

### DIFF
--- a/lib/decidim/census_connector/verifications/census/action_authorizer.rb
+++ b/lib/decidim/census_connector/verifications/census/action_authorizer.rb
@@ -110,9 +110,7 @@ module Decidim
             I18n.t(document_type, scope: "census.api.person.document_type")
           end
 
-          def allowed_document_types
-            @allowed_document_types.split(",").map(&:chomp)
-          end
+          attr_reader :allowed_document_types
 
           def minimum_age
             @minimum_age&.to_i

--- a/spec/system/verifications/census_create_spec.rb
+++ b/spec/system/verifications/census_create_spec.rb
@@ -28,7 +28,7 @@ describe "Census verification workflow", type: :system do
           "authorization_handler_name" => "census",
           "options" => {
             "minimum_age" => 18,
-            "allowed_document_types" => "dni,nie"
+            "allowed_document_types" => %w(dni nie)
           }
         }
       }


### PR DESCRIPTION
I have an idea on how to make decidim admins not having to learn JSON, and I'll be implementing it soon. For now, though, using strict JSON is better because it can be more easily validated via manifest hooks.