### PR TITLE
Fix bad folder name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 
 desc "Generates a development app."
 task development_app: "decidim:generate_external_development_app" do
-  Dir.chdir("spec/decidim_dummy_app") do
+  Dir.chdir("development_app") do
     sh("bin/rails generate decidim:census_connector:install")
   end
 end


### PR DESCRIPTION
In #16 I introduced this bad folder name. The development application conventionally lives at `development_app/`.