### PR TITLE
Don't use local scope as default scope in registration form

### DIFF
--- a/app/assets/javascripts/decidim/census_connector/verifications/census.js.es6
+++ b/app/assets/javascripts/decidim/census_connector/verifications/census.js.es6
@@ -19,18 +19,16 @@ $(() => {
     const $addressScope = $("#data_handler_address_scope_id");
     if ($addressScope.length > 0) {
       const $scope = $("#scope_selector");
-      const $hidden = $("input[type=hidden]", $addressScope);
       const localScopeRanges = $addressScope.parent().data("localScopeRanges");
-      const toggleScope = () => {
-        const addressScopeId = $hidden.val();
-        if (localScopeRanges.some(range => range[0] <= addressScopeId && addressScopeId <= range[1])) {
+      const toggleScope = (addressScopeId) => {
+        if (addressScopeId == null || localScopeRanges.some(range => range[0] <= addressScopeId && addressScopeId <= range[1])) {
           $scope.hide();
         } else {
           $scope.show();
         }
       }
-      toggleScope();
-      $hidden.on('change', toggleScope);
+      toggleScope($("input[type=hidden]", $addressScope).val());
+      $addressScope.on("change", "input[type=hidden]", (event) => toggleScope($(event.target).val()));
     }
 
     const $documentUploader = $(".document_uploader input[type=file]");

--- a/app/forms/decidim/census_connector/verifications/census/data_handler.rb
+++ b/app/forms/decidim/census_connector/verifications/census/data_handler.rb
@@ -39,7 +39,7 @@ module Decidim
           validates :document_scope, presence: true, unless: :local_document?
           validates :gender, inclusion: { in: genders.values }, presence: true
           validates :postal_code, presence: true, format: { with: /\A[0-9]*\z/, message: I18n.t("errors.messages.uppercase_only_letters_numbers") }
-          validates :scope_id, :address_scope_id, presence: true
+          validates :scope, :address_scope_id, presence: true
 
           validate :over_min_age
 

--- a/app/forms/decidim/census_connector/verifications/census/data_handler.rb
+++ b/app/forms/decidim/census_connector/verifications/census/data_handler.rb
@@ -44,8 +44,6 @@ module Decidim
           validate :over_min_age
 
           def use_default_values
-            @document_scope_id = @address_scope_id = @scope_id = local_scope.id
-            @document_scope = @address_scope = @scope = local_scope
             @document_type = self.class.document_types.values.first
           end
 

--- a/app/views/decidim/census_connector/verifications/census/authorizations/data.html.erb
+++ b/app/views/decidim/census_connector/verifications/census/authorizations/data.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en %>
-
 <div class="wrapper">
   <div class="row collapse">
     <div class="row collapse">
@@ -96,4 +94,5 @@
   </div>
 </div>
 
+<%= javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en %>
 <%= javascript_include_tag 'decidim/census_connector/verifications/census' %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,7 @@ Decidim::Dev.dummy_app_path = File.expand_path(File.join("spec", "decidim_dummy_
 require "decidim/dev/test/base_spec_helper"
 
 require "support/vcr"
+
+RSpec.configure do |config|
+  config.include Capybara::ScopesPicker, type: :system
+end

--- a/spec/system/verifications/census_create_spec.rb
+++ b/spec/system/verifications/census_create_spec.rb
@@ -11,7 +11,7 @@ describe "Census verification workflow", type: :system do
     create(:organization, available_authorizations: ["census"])
   end
 
-  let!(:scope) { create(:scope, code: "ES", id: 1) }
+  let!(:scope) { create(:scope, code: "ES", organization: organization, id: 1) }
 
   let(:user) do
     create(:user, :confirmed, base_user_params.merge(extra_user_params))
@@ -183,6 +183,7 @@ describe "Census verification workflow", type: :system do
     find(".datepicker-dropdown .month:not(.new):not(.old)", text: month, exact_text: true).click
     find(".datepicker-dropdown .day:not(.new):not(.old)", text: day, exact_text: true).click
 
+    scope_pick scopes_picker_find(:data_handler_address_scope_id), scope
     fill_in "Address", with: "Rua del Percebe, 1"
     fill_in "Postal code", with: "08001"
 


### PR DESCRIPTION
Is better to leave empty to force the user to select it. Now, with scopes better organized, it is very easy to reach the local scope.