### PR TITLE
Api interaction refactor

### DIFF
--- a/app/commands/decidim/census_connector/verifications/census/perform_census_data_step.rb
+++ b/app/commands/decidim/census_connector/verifications/census/perform_census_data_step.rb
@@ -14,7 +14,7 @@ module Decidim
 
               authorization.update!(metadata: { "person_id" => person_id })
             else
-              ::Census::API::Person.update(handler.census_qualified_id, person_params)
+              person.update(person_params)
             end
 
             broadcast :ok

--- a/app/commands/decidim/census_connector/verifications/census/perform_census_membership_level_step.rb
+++ b/app/commands/decidim/census_connector/verifications/census/perform_census_membership_level_step.rb
@@ -14,7 +14,7 @@ module Decidim
           private
 
           def update_membership_level
-            ::Census::API::Person.create_membership_level(handler.census_qualified_id, membership_level_params)
+            person.create_membership_level(membership_level_params)
           end
 
           def membership_level_params

--- a/app/commands/decidim/census_connector/verifications/census/perform_census_step.rb
+++ b/app/commands/decidim/census_connector/verifications/census/perform_census_step.rb
@@ -29,6 +29,10 @@ module Decidim
 
           private
 
+          def person
+            @person ||= ::Census::API::Person.new(handler.census_qualified_id)
+          end
+
           def attributes
             handler.attributes.except(:user, :handler_name)
           end

--- a/app/commands/decidim/census_connector/verifications/census/perform_census_step.rb
+++ b/app/commands/decidim/census_connector/verifications/census/perform_census_step.rb
@@ -27,13 +27,11 @@ module Decidim
             perform
           end
 
-          protected
+          private
 
           def attributes
             handler.attributes.except(:user, :handler_name)
           end
-
-          private
 
           attr_reader :authorization, :handler
         end

--- a/app/commands/decidim/census_connector/verifications/census/perform_census_verification_step.rb
+++ b/app/commands/decidim/census_connector/verifications/census/perform_census_verification_step.rb
@@ -14,7 +14,7 @@ module Decidim
           private
 
           def create_verification
-            ::Census::API::Person.create_verification(handler.census_qualified_id, verification_params)
+            person.create_verification(verification_params)
           end
 
           def verification_params

--- a/app/forms/decidim/census_connector/verifications/census/data_handler.rb
+++ b/app/forms/decidim/census_connector/verifications/census/data_handler.rb
@@ -12,11 +12,11 @@ module Decidim
           end
 
           def self.document_types
-            ::Census::API::Person.document_types
+            Person.document_types
           end
 
           def self.genders
-            ::Census::API::Person.genders
+            Person.genders
           end
 
           attribute :first_name, String
@@ -76,7 +76,7 @@ module Decidim
           end
 
           def local_document?
-            ::Census::API::Person.local_document? document_type
+            Person.local_document? document_type
           end
 
           def verified?

--- a/app/forms/decidim/census_connector/verifications/census/membership_level_handler.rb
+++ b/app/forms/decidim/census_connector/verifications/census/membership_level_handler.rb
@@ -10,7 +10,7 @@ module Decidim
           attribute :membership_level, Symbol
 
           def self.membership_levels
-            ::Census::API::Person.membership_levels
+            Person.membership_levels
           end
         end
       end

--- a/app/models/census/api/census_api.rb
+++ b/app/models/census/api/census_api.rb
@@ -16,6 +16,8 @@ module Census
         http_proxy Decidim::CensusConnector.census_api_proxy_address, Decidim::CensusConnector.census_api_proxy_port if Decidim::CensusConnector.census_api_proxy_address.present?
 
         debug_output if Decidim::CensusConnector.census_api_debug
+
+        delegate :send_request, :get, :patch, :post, to: :class
       end
 
       class_methods do

--- a/app/models/census/api/definitions.rb
+++ b/app/models/census/api/definitions.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Census
+  module API
+    # Container module for Census API constants
+    module Definitions
+      extend ActiveSupport::Concern
+
+      DOCUMENT_TYPES = %w(dni nie passport).freeze
+      GENDERS = %w(female male other undisclosed).freeze
+      MEMBERSHIP_LEVELS = %w(follower member).freeze
+      STATES = %w(pending enabled cancelled trashed).freeze
+      VERIFICATIONS = %w(not_verified verification_requested verified mistake fraudulent).freeze
+
+      class_methods do
+        def document_types
+          @document_types ||= Hash[DOCUMENT_TYPES.map { |type| [I18n.t("census.api.person.document_type.#{type}"), type] }].freeze
+        end
+
+        def genders
+          @genders ||= Hash[GENDERS.map { |gender| [I18n.t("census.api.person.gender.#{gender}"), gender] }].freeze
+        end
+
+        def membership_levels
+          @membership_levels ||= Hash[MEMBERSHIP_LEVELS.map do |membership_level|
+            [I18n.t("census.api.person.membership_level.#{membership_level}"), membership_level]
+          end].freeze
+        end
+
+        def local_document?(document_type)
+          document_type != "passport"
+        end
+      end
+    end
+  end
+end

--- a/app/models/census/api/person.rb
+++ b/app/models/census/api/person.rb
@@ -3,7 +3,9 @@
 module Census
   module API
     # This class represents a person in Census
-    class Person < CensusAPI
+    class Person
+      include CensusAPI
+
       DOCUMENT_TYPES = %w(dni nie passport).freeze
       GENDERS = %w(female male other undisclosed).freeze
       MEMBERSHIP_LEVELS = %w(follower member).freeze

--- a/app/models/census/api/person.rb
+++ b/app/models/census/api/person.rb
@@ -6,30 +6,6 @@ module Census
     class Person
       include CensusAPI
 
-      DOCUMENT_TYPES = %w(dni nie passport).freeze
-      GENDERS = %w(female male other undisclosed).freeze
-      MEMBERSHIP_LEVELS = %w(follower member).freeze
-      STATES = %w(pending enabled cancelled trashed).freeze
-      VERIFICATIONS = %w(not_verified verification_requested verified mistake fraudulent).freeze
-
-      def self.document_types
-        @document_types ||= Hash[DOCUMENT_TYPES.map { |type| [I18n.t("census.api.person.document_type.#{type}"), type] }].freeze
-      end
-
-      def self.genders
-        @genders ||= Hash[GENDERS.map { |gender| [I18n.t("census.api.person.gender.#{gender}"), gender] }].freeze
-      end
-
-      def self.membership_levels
-        @membership_levels ||= Hash[MEMBERSHIP_LEVELS.map do |membership_level|
-          [I18n.t("census.api.person.membership_level.#{membership_level}"), membership_level]
-        end].freeze
-      end
-
-      def self.local_document?(document_type)
-        document_type != "passport"
-      end
-
       # PUBLIC creates a person with the given params.
       def self.create(params)
         response = send_request do
@@ -45,15 +21,21 @@ module Census
         end
       end
 
-      # PUBLIC update the given person with the given params.
-      def self.update(qualified_id, params)
+      attr_reader :qualified_id
+
+      def initialize(qualified_id)
+        @qualified_id = qualified_id
+      end
+
+      # PUBLIC update the person with the given params.
+      def update(params)
         send_request do
           patch("/api/v1/people/#{qualified_id}", body: params)
         end
       end
 
-      # PUBLIC add a verification process for the given person.
-      def self.create_verification(qualified_id, params)
+      # PUBLIC add a verification process for the person.
+      def create_verification(params)
         files = params[:files].map do |file|
           {
             filename: file.original_filename,
@@ -67,7 +49,8 @@ module Census
         end
       end
 
-      def self.create_membership_level(qualified_id, params)
+      # PUBLIC associate a membership level for the person.
+      def create_membership_level(params)
         send_request do
           post("/api/v1/people/#{qualified_id}/membership_levels", body: params)
         end

--- a/app/models/census/api/person.rb
+++ b/app/models/census/api/person.rb
@@ -28,7 +28,7 @@ module Census
         document_type != "passport"
       end
 
-      # PUBLIC creates the person with the given params.
+      # PUBLIC creates a person with the given params.
       def self.create(params)
         response = send_request do
           post("/api/v1/people", body: params)

--- a/app/models/census/api/person.rb
+++ b/app/models/census/api/person.rb
@@ -38,17 +38,17 @@ module Census
         response[:person_id]
       end
 
-      # PUBLIC update the given person with the given params.
-      def self.update(qualified_id, params)
-        send_request do
-          patch("/api/v1/people/#{qualified_id}", body: params)
-        end
-      end
-
       # PUBLIC retrieve the available information for the given person.
       def self.find(qualified_id)
         send_request do
           get("/api/v1/people/#{qualified_id}")
+        end
+      end
+
+      # PUBLIC update the given person with the given params.
+      def self.update(qualified_id, params)
+        send_request do
+          patch("/api/v1/people/#{qualified_id}", body: params)
         end
       end
 

--- a/app/models/decidim/census_connector/person.rb
+++ b/app/models/decidim/census_connector/person.rb
@@ -12,6 +12,30 @@ module Decidim
       delegate :id, to: :address_scope, prefix: true
       delegate :id, to: :document_scope, prefix: true
 
+      DOCUMENT_TYPES = %w(dni nie passport).freeze
+      GENDERS = %w(female male other undisclosed).freeze
+      MEMBERSHIP_LEVELS = %w(follower member).freeze
+      STATES = %w(pending enabled cancelled trashed).freeze
+      VERIFICATIONS = %w(not_verified verification_requested verified mistake fraudulent).freeze
+
+      def self.document_types
+        @document_types ||= Hash[DOCUMENT_TYPES.map { |type| [I18n.t("census.api.person.document_type.#{type}"), type] }].freeze
+      end
+
+      def self.genders
+        @genders ||= Hash[GENDERS.map { |gender| [I18n.t("census.api.person.gender.#{gender}"), gender] }].freeze
+      end
+
+      def self.membership_levels
+        @membership_levels ||= Hash[MEMBERSHIP_LEVELS.map do |membership_level|
+          [I18n.t("census.api.person.membership_level.#{membership_level}"), membership_level]
+        end].freeze
+      end
+
+      def self.local_document?(document_type)
+        document_type != "passport"
+      end
+
       def initialize(person_data)
         @person_data = OpenStruct.new(person_data)
       end
@@ -37,9 +61,9 @@ module Decidim
       end
 
       {
-        state: Census::API::Person::STATES,
-        verification: Census::API::Person::VERIFICATIONS,
-        membership_level: Census::API::Person::MEMBERSHIP_LEVELS
+        state: STATES,
+        verification: VERIFICATIONS,
+        membership_level: MEMBERSHIP_LEVELS
       }.each do |attribute, values|
         values.each do |value|
           define_method "#{value}?" do

--- a/app/models/decidim/census_connector/person.rb
+++ b/app/models/decidim/census_connector/person.rb
@@ -3,6 +3,8 @@
 module Decidim
   module CensusConnector
     class Person
+      include Census::API::Definitions
+
       delegate :first_name, :last_name1, :last_name2, to: :person_data
       delegate :document_type, :document_id, to: :person_data
       delegate :address, :postal_code, to: :person_data
@@ -11,30 +13,6 @@ module Decidim
       delegate :id, to: :scope, prefix: true
       delegate :id, to: :address_scope, prefix: true
       delegate :id, to: :document_scope, prefix: true
-
-      DOCUMENT_TYPES = %w(dni nie passport).freeze
-      GENDERS = %w(female male other undisclosed).freeze
-      MEMBERSHIP_LEVELS = %w(follower member).freeze
-      STATES = %w(pending enabled cancelled trashed).freeze
-      VERIFICATIONS = %w(not_verified verification_requested verified mistake fraudulent).freeze
-
-      def self.document_types
-        @document_types ||= Hash[DOCUMENT_TYPES.map { |type| [I18n.t("census.api.person.document_type.#{type}"), type] }].freeze
-      end
-
-      def self.genders
-        @genders ||= Hash[GENDERS.map { |gender| [I18n.t("census.api.person.gender.#{gender}"), gender] }].freeze
-      end
-
-      def self.membership_levels
-        @membership_levels ||= Hash[MEMBERSHIP_LEVELS.map do |membership_level|
-          [I18n.t("census.api.person.membership_level.#{membership_level}"), membership_level]
-        end].freeze
-      end
-
-      def self.local_document?(document_type)
-        document_type != "passport"
-      end
 
       def initialize(person_data)
         @person_data = OpenStruct.new(person_data)

--- a/app/presenters/decidim/census_connector/account/account_presenter.rb
+++ b/app/presenters/decidim/census_connector/account/account_presenter.rb
@@ -17,7 +17,7 @@ module Decidim
 
         def full_document
           ret = "#{I18n.t(person.document_type, scope: "census.api.person.document_type")} #{person.document_id}"
-          ret += " (#{translated_attribute(@person.document_scope.name)})" unless ::Census::API::Person.local_document? person.document_type
+          ret += " (#{translated_attribute(@person.document_scope.name)})" unless Person.local_document? person.document_type
           ret
         end
 


### PR DESCRIPTION
Depends on #34.

The idea is that `Census::API::Person` contains strictly the interaction with the census API, whereas `Decidim::CensusConnector::Person` contains the rest of the logic related to persons.

To me the code is simpler to understand now, do you agree @leio10?