### PR TITLE
Refactor seeds

### DIFF
--- a/lib/decidim/census_connector/engine.rb
+++ b/lib/decidim/census_connector/engine.rb
@@ -26,22 +26,11 @@ module Decidim
       end
 
       def load_seed
+        Decidim::Scope.delete_all
+        Decidim::ScopeType.delete_all
+
         Decidim::Organization.find_each do |organization|
-          break if Decidim::Scope.find_by(code: "ES", organization: organization)
-
-          country = Decidim::ScopeType.create_with(
-            plural: Decidim::Faker::Localized.literal("countries")
-          ).find_or_initialize_by(
-            name: Decidim::Faker::Localized.literal("country"),
-            organization: organization
-          )
-
-          Decidim::Scope.create!(
-            code: "ES",
-            organization: organization,
-            name: Decidim::Faker::Localized.literal(::Faker::Address.unique.state),
-            scope_type: country
-          )
+          Decidim::CensusConnector::Seeds::Scopes.new(organization).seed
         end
       end
     end

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -43,9 +43,12 @@ module Decidim
 
         def save_scopes(main_source, translations_source)
           puts "Loading scopes..."
-          return if load_cached_scopes
 
-          load_original_scopes
+          if File.exist?(CACHE_PATH)
+            load_cached_scopes
+          else
+            load_original_scopes
+          end
         end
 
         def load_original_scopes
@@ -61,15 +64,12 @@ module Decidim
         end
 
         def load_cached_scopes
-          return unless File.exist?(CACHE_PATH)
-
           conn = ActiveRecord::Base.connection.raw_connection
           File.open(CACHE_PATH, "r:ASCII-8BIT") do |file|
             conn.copy_data "COPY decidim_scopes FROM STDOUT With CSV HEADER DELIMITER E'\t' NULL '' ENCODING 'UTF8'" do
               conn.put_copy_data(file.readline) until file.eof?
             end
           end
-          true
         end
 
         def cache_scopes

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -9,27 +9,11 @@ module Decidim
         EXTERIOR_SCOPE = "XX"
         CACHE_PATH = Rails.root.join("tmp", "cache", "#{Rails.env}_scopes.csv").freeze
 
-        class << self
-          def instance
-            @instance ||= Scopes.new
-          end
-
-          def seed(organization, options = {})
-            instance.seed organization, options
-          end
-
-          def cache_scopes
-            conn = ActiveRecord::Base.connection.raw_connection
-            File.open(CACHE_PATH, "w:ASCII-8BIT") do |file|
-              conn.copy_data "COPY (SELECT * FROM decidim_scopes) To STDOUT With CSV HEADER DELIMITER E'\t' NULL '' ENCODING 'UTF8'" do
-                while (row = conn.get_copy_data) do file.puts row end
-              end
-            end
-          end
+        def initialize(organization)
+          @organization = organization
         end
 
-        def seed(organization, options = {})
-          @organization = organization
+        def seed(options = {})
           base_path = options[:base_path] || File.expand_path(File.join("..", "..", "..", "..", "db", "seeds"), __dir__)
           @path = File.join(base_path, "scopes")
 
@@ -83,6 +67,15 @@ module Decidim
             end
           end
           true
+        end
+
+        def cache_scopes
+          conn = ActiveRecord::Base.connection.raw_connection
+          File.open(CACHE_PATH, "w:ASCII-8BIT") do |file|
+            conn.copy_data "COPY (SELECT * FROM decidim_scopes) To STDOUT With CSV HEADER DELIMITER E'\t' NULL '' ENCODING 'UTF8'" do
+              while (row = conn.get_copy_data) do file.puts row end
+            end
+          end
         end
 
         def root_code(code)

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -20,7 +20,11 @@ module Decidim
           save_scope_types("#{base_path}/scope_types.tsv")
 
           puts "Loading scopes..."
-          save_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
+          if File.exist?(CACHE_PATH)
+            load_cached_scopes
+          else
+            load_original_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
+          end
         end
 
         private
@@ -43,15 +47,7 @@ module Decidim
           end
         end
 
-        def save_scopes(main_source, translations_source)
-          if File.exist?(CACHE_PATH)
-            load_cached_scopes
-          else
-            load_original_scopes
-          end
-        end
-
-        def load_original_scopes
+        def load_original_scopes(main_source, translations_source)
           @translations = Hash.new { |h, k| h[k] = {} }
           CSV.foreach(translations_source, col_sep: "\t", headers: true) do |row|
             @translations[row["UID"]][row["Locale"]] = row["Translation"]

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -25,6 +25,7 @@ module Decidim
             load_cached_scopes(cache_path)
           else
             load_original_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
+            cache_scopes(cache_path)
           end
         end
 

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -16,14 +16,16 @@ module Decidim
         def seed(options = {})
           base_path = options[:base_path] || File.expand_path("../../../../db/seeds/scopes", __dir__)
 
+          puts "Loading scope types..."
           save_scope_types("#{base_path}/scope_types.tsv")
+
+          puts "Loading scopes..."
           save_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
         end
 
         private
 
         def save_scope_types(source)
-          puts "Loading scope types..."
           @scope_types = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = {} } }
           CSV.foreach(source, col_sep: "\t", headers: true) do |row|
             @scope_types[row["Code"]][:id] = row["UID"]
@@ -42,8 +44,6 @@ module Decidim
         end
 
         def save_scopes(main_source, translations_source)
-          puts "Loading scopes..."
-
           if File.exist?(CACHE_PATH)
             load_cached_scopes
           else

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -14,10 +14,10 @@ module Decidim
         end
 
         def seed(options = {})
-          base_path = options[:base_path] || File.expand_path(File.join("..", "..", "..", "..", "db", "seeds", "scopes"), __dir__)
+          base_path = options[:base_path] || File.expand_path("../../../../db/seeds/scopes", __dir__)
 
-          save_scope_types(File.join(base_path, "scope_types.tsv"))
-          save_scopes(File.join(base_path, "scopes.tsv"), File.join(base_path, "scopes.translations.tsv"))
+          save_scope_types("#{base_path}/scope_types.tsv")
+          save_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
         end
 
         private

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -17,16 +17,16 @@ module Decidim
           base_path = options[:base_path] || File.expand_path(File.join("..", "..", "..", "..", "db", "seeds"), __dir__)
           @path = File.join(base_path, "scopes")
 
-          save_scope_types
-          save_scopes
+          save_scope_types(File.join(@path, "scope_types.tsv"))
+          save_scopes(File.join(@path, "scopes.tsv"), File.join(@path, "scopes.translations.tsv"))
         end
 
         private
 
-        def save_scope_types
+        def save_scope_types(source)
           puts "Loading scope types..."
           @scope_types = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = {} } }
-          CSV.foreach(File.join(@path, "scope_types.tsv"), col_sep: "\t", headers: true) do |row|
+          CSV.foreach(source, col_sep: "\t", headers: true) do |row|
             @scope_types[row["Code"]][:id] = row["UID"]
             @scope_types[row["Code"]][:organization] = @organization
             @scope_types[row["Code"]][:name][row["Locale"]] = row["Singular"]
@@ -42,17 +42,17 @@ module Decidim
           end
         end
 
-        def save_scopes
+        def save_scopes(main_source, translations_source)
           puts "Loading scopes..."
           return if use_cached_scopes
 
           @translations = Hash.new { |h, k| h[k] = {} }
-          CSV.foreach(File.join(@path, "scopes.translations.tsv"), col_sep: "\t", headers: true) do |row|
+          CSV.foreach(translations_source, col_sep: "\t", headers: true) do |row|
             @translations[row["UID"]][row["Locale"]] = row["Translation"]
           end
 
           @scope_ids = {}
-          CSV.foreach(File.join(@path, "scopes.tsv"), col_sep: "\t", headers: true) do |row|
+          CSV.foreach(main_source, col_sep: "\t", headers: true) do |row|
             save_scope row
           end
         end

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -15,13 +15,14 @@ module Decidim
 
         def seed(options = {})
           base_path = options[:base_path] || File.expand_path("../../../../db/seeds/scopes", __dir__)
+          cache_path = ENV["SCOPES_CACHE_PATH"].presence || CACHE_PATH
 
           puts "Loading scope types..."
           save_scope_types("#{base_path}/scope_types.tsv")
 
           puts "Loading scopes..."
-          if File.exist?(CACHE_PATH)
-            load_cached_scopes(CACHE_PATH)
+          if File.exist?(cache_path)
+            load_cached_scopes(cache_path)
           else
             load_original_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
           end

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -14,11 +14,10 @@ module Decidim
         end
 
         def seed(options = {})
-          base_path = options[:base_path] || File.expand_path(File.join("..", "..", "..", "..", "db", "seeds"), __dir__)
-          @path = File.join(base_path, "scopes")
+          base_path = options[:base_path] || File.expand_path(File.join("..", "..", "..", "..", "db", "seeds", "scopes"), __dir__)
 
-          save_scope_types(File.join(@path, "scope_types.tsv"))
-          save_scopes(File.join(@path, "scopes.tsv"), File.join(@path, "scopes.translations.tsv"))
+          save_scope_types(File.join(base_path, "scope_types.tsv"))
+          save_scopes(File.join(base_path, "scopes.tsv"), File.join(base_path, "scopes.translations.tsv"))
         end
 
         private

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -21,7 +21,7 @@ module Decidim
 
           puts "Loading scopes..."
           if File.exist?(CACHE_PATH)
-            load_cached_scopes
+            load_cached_scopes(CACHE_PATH)
           else
             load_original_scopes("#{base_path}/scopes.tsv", "#{base_path}/scopes.translations.tsv")
           end
@@ -59,18 +59,18 @@ module Decidim
           end
         end
 
-        def load_cached_scopes
+        def load_cached_scopes(source)
           conn = ActiveRecord::Base.connection.raw_connection
-          File.open(CACHE_PATH, "r:ASCII-8BIT") do |file|
+          File.open(source, "r:ASCII-8BIT") do |file|
             conn.copy_data "COPY decidim_scopes FROM STDOUT With CSV HEADER DELIMITER E'\t' NULL '' ENCODING 'UTF8'" do
               conn.put_copy_data(file.readline) until file.eof?
             end
           end
         end
 
-        def cache_scopes
+        def cache_scopes(target)
           conn = ActiveRecord::Base.connection.raw_connection
-          File.open(CACHE_PATH, "w:ASCII-8BIT") do |file|
+          File.open(target, "w:ASCII-8BIT") do |file|
             conn.copy_data "COPY (SELECT * FROM decidim_scopes) To STDOUT With CSV HEADER DELIMITER E'\t' NULL '' ENCODING 'UTF8'" do
               while (row = conn.get_copy_data) do file.puts row end
             end

--- a/lib/decidim/census_connector/seeds/scopes.rb
+++ b/lib/decidim/census_connector/seeds/scopes.rb
@@ -43,8 +43,12 @@ module Decidim
 
         def save_scopes(main_source, translations_source)
           puts "Loading scopes..."
-          return if use_cached_scopes
+          return if load_cached_scopes
 
+          load_original_scopes
+        end
+
+        def load_original_scopes
           @translations = Hash.new { |h, k| h[k] = {} }
           CSV.foreach(translations_source, col_sep: "\t", headers: true) do |row|
             @translations[row["UID"]][row["Locale"]] = row["Translation"]
@@ -56,7 +60,7 @@ module Decidim
           end
         end
 
-        def use_cached_scopes
+        def load_cached_scopes
           return unless File.exist?(CACHE_PATH)
 
           conn = ActiveRecord::Base.connection.raw_connection

--- a/lib/generators/decidim/census_connector/install/install_generator.rb
+++ b/lib/generators/decidim/census_connector/install/install_generator.rb
@@ -10,7 +10,7 @@ module Decidim
         DESC
 
         def self.source_root
-          @source_root ||= File.expand_path(File.join(__dir__, "templates"))
+          @source_root ||= File.expand_path("templates", __dir__)
         end
 
         def copy_configuration

--- a/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
+++ b/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::CensusConnector::Seeds::Scopes do
   describe "#seed" do
     subject(:method) { described_class.seed organization, base_path: base_path }
 
-    before { FileUtils.rm_rf(Decidim::CensusConnector::Seeds::Scopes::CACHE_PATH) }
+    before { FileUtils.rm_rf(described_class::CACHE_PATH) }
 
     let(:organization) { create(:organization) }
     let(:base_path) { File.expand_path("../../../../fixtures/seeds/scopes", __dir__) }

--- a/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
+++ b/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::CensusConnector::Seeds::Scopes do
     before { FileUtils.rm_rf(Decidim::CensusConnector::Seeds::Scopes::CACHE_PATH) }
 
     let(:organization) { create(:organization) }
-    let(:base_path) { File.expand_path("../../../../fixtures/seeds", __dir__) }
+    let(:base_path) { File.expand_path("../../../../fixtures/seeds/scopes", __dir__) }
     let(:instance) { described_class.instance }
 
     it "loads scopes data" do

--- a/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
+++ b/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
@@ -30,7 +30,7 @@ describe Decidim::CensusConnector::Seeds::Scopes do
     context "when data is cached" do
       before do
         described_class.seed organization, base_path: base_path
-        described_class.cache_scopes
+        described_class.cache_scopes(CACHE_PATH)
         Decidim::Scope.delete_all
       end
 

--- a/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
+++ b/spec/lib/decidim/census_connector/seeds/scopes_spec.rb
@@ -6,41 +6,48 @@ require "decidim/census_connector/seeds/scopes"
 
 describe Decidim::CensusConnector::Seeds::Scopes do
   describe "#seed" do
-    subject(:method) { described_class.seed organization, base_path: base_path }
-
-    before { FileUtils.rm_rf(described_class::CACHE_PATH) }
+    before do
+      FileUtils.rm_rf(described_class::CACHE_PATH)
+      ENV["SCOPES_CACHE_PATH"] = nil
+    end
 
     let(:organization) { create(:organization) }
     let(:base_path) { File.expand_path("../../../../fixtures/seeds/scopes", __dir__) }
-    let(:instance) { described_class.instance }
+    let(:instance) { described_class.new(organization) }
 
     it "loads scopes data" do
-      expect { subject } .to change { Decidim::Scope.count } .from(0).to(20)
+      expect { instance.seed(base_path: base_path) } .to change { Decidim::Scope.count } .from(0).to(20)
     end
 
     it "loads scope types data" do
-      expect { subject } .to change { Decidim::ScopeType.count } .from(0).to(7)
+      expect { instance.seed(base_path: base_path) } .to change { Decidim::ScopeType.count } .from(0).to(7)
     end
 
     it "loads scope data from files" do
       expect(instance).to receive(:save_scope).at_least(1)
-      subject
+
+      instance.seed(base_path: base_path)
+    end
+
+    it "caches scopes after loading originals" do
+      expect { instance.seed(base_path: base_path) } .to change { File.exist?(described_class::CACHE_PATH) } .from(false).to(true)
     end
 
     context "when data is cached" do
       before do
-        described_class.seed organization, base_path: base_path
-        described_class.cache_scopes(CACHE_PATH)
+        instance.seed(base_path: base_path)
+
         Decidim::Scope.delete_all
       end
 
       it "load cached scopes data" do
-        expect { subject } .to change { Decidim::Scope.count } .from(0).to(20)
+        expect { instance.seed(base_path: base_path) } .to change { Decidim::Scope.count } .from(0).to(20)
       end
 
       it "doesn't load scope data from files" do
         expect(instance).not_to receive(:save_scope)
-        subject
+
+        instance.seed(base_path: base_path)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require "decidim/dev"
 
 ENV["ENGINE_NAME"] = File.dirname(__dir__).split("/").last
 
-Decidim::Dev.dummy_app_path = File.expand_path(File.join("spec", "decidim_dummy_app"))
+Decidim::Dev.dummy_app_path = File.expand_path("spec/decidim_dummy_app")
 
 require "decidim/dev/test/base_spec_helper"
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -5,10 +5,7 @@ VCR.configure do |config|
     URI(request.uri).port != URI(ENV["CENSUS_URL"]).port
   end
 
-  config.cassette_library_dir = File.expand_path(
-    File.join("..", "fixtures", "vcr"),
-    __dir__
-  )
+  config.cassette_library_dir = File.expand_path("../fixtures/vcr", __dir__)
 
   config.hook_into :webmock
 end


### PR DESCRIPTION
My purpose here was:

*  Cache the loaded scopes after seeding the "original scopes" so that second time loads faster (we were trying to use cached scopes if they were there, but never actually saving to the cache unless done manually).
* Make sure the generated dummy app has proper census scopes loaded. Otherwise, you get errors when connecting to census because the chosen scopes are not found in census.
* Allow configuring a cache path that does not live inside the application. This can be handy so that if you regenerate the dummy app, you don't need to wait for all the scopes to get loaded again.
* Easier scope loading from participa2.

While doing this, I refactored the `Seeds::Scopes` class a bit.